### PR TITLE
Avoided failures in name related API methods

### DIFF
--- a/countryinfo/countryinfo.py
+++ b/countryinfo/countryinfo.py
@@ -71,9 +71,9 @@ class CountryInfo:
             # pprint(_iso)
 
             if alpha == 2:
-                return _iso['alpha2']
+                return _iso.get('alpha2')
             elif alpha == 3:
-                return _iso['alpha3']
+                return _iso.get('alpha3')
 
             return _iso
 

--- a/countryinfo/countryinfo.py
+++ b/countryinfo/countryinfo.py
@@ -27,10 +27,11 @@ class CountryInfo:
         self.__countries = {}
         for file_path in __files_path:
             if isfile(file_path):
-                country_info = json.load(open(file_path))
-                # pprint(country_info)
-                if country_info.get('name', None):
-                    self.__countries[country_info['name'].lower()] = country_info
+                with open(file_path, encoding='utf-8') as file:
+                    country_info = json.load(file)
+                    # pprint(country_info)
+                    if country_info.get('name', None):
+                        self.__countries[country_info['name'].lower()] = country_info
 
 
     def info(self):

--- a/countryinfo/countryinfo.py
+++ b/countryinfo/countryinfo.py
@@ -84,10 +84,13 @@ class CountryInfo:
         :return: list
         """
         if self.__country_name:
-            _alt_spellings = self.__countries[self.__country_name]['altSpellings']
-            # pprint(_alt_spellings)
+            try:
+                _alt_spellings = self.__countries[self.__country_name]['altSpellings']
+                # pprint(_alt_spellings)
 
-            return _alt_spellings
+                return _alt_spellings
+            except KeyError:
+                return []
     
     
     def area(self):
@@ -148,7 +151,8 @@ class CountryInfo:
             # pprint(_currencies)
 
             return _currencies
-    
+
+
     
     def demonym(self):
         """Returns the demonyms for a specified country
@@ -209,15 +213,21 @@ class CountryInfo:
             # pprint(_latlng)
 
             return _latlng
-    
-    
+
+    def name(self):
+        """Returns the english name of the country as registered in the library
+
+        :return: str
+        """
+        return self.__country_name
+
     def native_name(self):
         """Returns the name of the country in its native tongue
 
         :return: str
         """
         if self.__country_name:
-            _native_name = self.__countries[self.__country_name]['nativeName']
+            _native_name = self.__countries[self.__country_name].get('nativeName')
             # pprint(_native_name)
 
             return _native_name
@@ -289,10 +299,13 @@ class CountryInfo:
         :return: dict
         """
         if self.__country_name:
-            _translations = self.__countries[self.__country_name]['translations']
-            # pprint(_translations)
+            try:
+                _translations = self.__countries[self.__country_name]['translations']
+                # pprint(_translations)
 
-            return _translations
+                return _translations
+            except KeyError:
+                return []
     
     
     def wiki(self):

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ setup(
         exclude='tests'
     ),
     include_package_data=True,
+    test_suite="tests.Tests",
     data_files=[("data", data_files)],  # package data files
     url='https://github.com/porimol/countryinfo',
     license='MIT License',

--- a/tests.py
+++ b/tests.py
@@ -3,8 +3,57 @@ from countryinfo import CountryInfo
 
 class Tests(unittest.TestCase):
 
-    def test_all_countries_have_names(self):
-        allCountries = CountryInfo().all()
+    all_countries = {}
+
+    def setUp(self):
+        """Loads all the countries just once for all the tests
+        """
+        if not self.all_countries:
+            print("Loading all countries...")
+            country_names = CountryInfo().all()
+            for name in country_names:
+                country = CountryInfo(name)
+                self.all_countries[name] = country
+
+    def test_all_countries_have_name(self):
+        for name in self.all_countries:
+            try:
+                country = self.all_countries[name]
+                self.assertIsNotNone(country.name())
+            except KeyError as err:
+                self.fail("Country '{0}' key error: {1}".format(name, err))
+
+    def test_all_countries_have_native_name(self):
+        for name in self.all_countries:
+            try:
+                country = self.all_countries[name]
+                country.native_name()
+            except KeyError as err:
+                self.fail("Country '{0}' key error: {1}".format(name, err))
+
+    def test_all_countries_have_iso(self):
+        for name in self.all_countries:
+            try:
+                country = self.all_countries[name]
+                country.iso()
+            except KeyError as err:
+                self.fail("Country '{0}' key error: {1}".format(name, err))
+
+    def test_all_countries_have_alt_spellings(self):
+        for name in self.all_countries:
+            try:
+                country = self.all_countries[name]
+                country.alt_spellings()
+            except KeyError as err:
+                self.fail("Country '{0}' key error: {1}".format(name, err))
+
+    def test_all_countries_have_translations(self):
+        for name in self.all_countries:
+            try:
+                country = self.all_countries[name]
+                country.translations()
+            except KeyError as err:
+                self.fail("Country '{0}' key error: {1}".format(name, err))
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests.py
+++ b/tests.py
@@ -1,0 +1,10 @@
+import unittest
+from countryinfo import CountryInfo
+
+class Tests(unittest.TestCase):
+
+    def test_all_countries_have_names(self):
+        allCountries = CountryInfo().all()
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Please first check PR #10 as it precedes this change.

I wanted to first demonstrate that the API methods right now are unsafe (throws KeyError or AttributeError at random). I did that with the tests. Then I fixed the methods to return empty arrays or None as appropriate.