### PR TITLE
Updated Ghana's regions: added Bono, Bono East, North East, Oti, Savannah,…

### DIFF
--- a/countryinfo/data/ghana.json
+++ b/countryinfo/data/ghana.json
@@ -158,15 +158,21 @@
   "population": 27043093,
   "provinces": [
     "Ashanti",
-    "Brong-Ahafo",
+    "Ahafo",
+    "Bono",
+    "Bono East",
     "Central",
     "Eastern",
     "Greater Accra",
     "Northern",
+    "North East",
+    "Oti",
+    "Savannah",
     "Upper East",
     "Upper West",
     "Volta",
-    "Western"
+    "Western",
+    "Western North"
   ],
   "region": "Africa",
   "subregion": "Sub-Saharan Africa",


### PR DESCRIPTION
… and Western North; removed Brong-Ahafo.