### PR TITLE
fixing for recent versions of poetry

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,9 @@ exclude = [
 ]
 max-line-length = 120
 
+[project]
+name = "countryinfo"
+
 [project.urls]
 Homepage = "https://github.com/porimol/countryinfo"
 Documentation = "https://github.com/porimol/countryinfo"


### PR DESCRIPTION
Recent versions of poetry insist on project.name being defined. This fixes that.