### PR TITLE
Update bulgaria.json

### DIFF
--- a/countryinfo/data/bulgaria.json
+++ b/countryinfo/data/bulgaria.json
@@ -3,6 +3,7 @@
   "altSpellings": [
     "BG",
     "Republic of Bulgaria",
+    "България",
     "Република България",
     "BGR"
   ],
@@ -23,7 +24,7 @@
     23.3221789
   ],
   "currencies": [
-    "BGN"
+    "EUR"
   ],
   "demonym": "Bulgarian",
   "flag": "",


### PR DESCRIPTION
- EUR since 1st Jan 2026
- България as native common name